### PR TITLE
Fix for dependabot workflow issue

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -5,6 +5,9 @@ on:
     branches: [main]
   pull_request:
     branches: [develop]
+  pull_request_target:
+    branches: [develop]
+    types: [opened, synchronize, reopened, ready_for_review]
 
 jobs:
   lint_test_build:
@@ -12,9 +15,20 @@ jobs:
     env:
       NEXT_PUBLIC_GRAPHQL_URL: ${{ secrets.NEXT_PUBLIC_GRAPHQL_URL }}
       NEXT_PUBLIC_TOKEN: ${{ secrets.NEXT_PUBLIC_TOKEN }}
+      
+    if: |
+      (github.event_name == 'pull_request_target' && github.actor == 'dependabot[bot]') ||
+      (github.event_name != 'pull_request_target' && github.actor != 'dependabot[bot]')
     steps:
       - name: Checkout code
+        if: ${{ github.event_name != 'pull_request_target' }}
         uses: actions/checkout@v2
+
+      - name: Checkout PR
+        if: ${{ github.event_name == 'pull_request_target' }}
+        uses: actions/checkout@v2
+        with:
+          ref: ${{ github.event.pull_request.head.sha }}
 
       - name: Install Node
         uses: actions/setup-node@v2


### PR DESCRIPTION
**Description**
Modified build.yml workflow file so that PR created by dependabot is also able run workflows successfully with needed secrets.

Changes are made based on the article:
https://hugo.alliau.me/2021/05/04/migration-to-github-native-dependabot-solutions-for-auto-merge-and-action-secrets/#share-your-secrets-with-dependabot

**File changes:**
- build.yml:
  - Added **pull_request_target** event detection which is used by dependabot.
  - Added if-statement to check and ensure that it really is dependabot who is triggering the **pull_request_target** event
  - Added different checkouts for **pull_request_target event** and other events

**Type of change**

- [x] Bug fix (non-breaking change which fixes an issue)

**People that worked on this**

@Koivunlehti 